### PR TITLE
Allow protecting branches via `git config buildkite.protectedBranches`

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,19 @@ You can automatically open the build in your browser, too:
 $ git buildkite --browse
 ```
 
+Prevent specific branches from being built:
+
+```
+$ git config --local buildkite.protectedBranches master,develop
+$ git buildkite master # error
+```
+
+Force a protected branch to be built:
+
+```
+$ git buildkite --force master
+```
+
 ## To Do
 
  * Better result parsing and error handling

--- a/git-buildkite
+++ b/git-buildkite
@@ -120,6 +120,14 @@ function current_head_dirty() {
   [ "$(git status --short)" ]
 }
 
+function protected_branches() {
+  git config buildkite.protectedBranches 2> /dev/null | tr ',' '\n'
+}
+
+function is_protected_branch() {
+  protected_branches | grep -q -- "$1"
+}
+
 function build() {
   # XXX: There seems no nice way to make curl give us a non-zero
   # status code and the response body on error, so we have to check
@@ -176,14 +184,20 @@ if [ -z "$BUILDKITE_ORGANIZATION" -o -z "$BUILDKITE_PIPELINE" ]; then
 fi
 
 # Parse flags before parsing arguments
-let i=1
-while [[ $i -le $# ]]; do
-  case "${!i}" in
+while [[ $# -gt 0 ]]; do
+  case "$1" in
     "--browse")
       browse=yes
-      shift $i
+      shift
+      ;;
+    "--force")
+      force=yes
+      shift
+      ;;
+    *)
+      break
+      ;;
   esac
-  let i=i+1
 done
 
 if [[ "$#" -eq 0 ]]; then
@@ -331,6 +345,26 @@ elif [[ "$#" -eq 2 ]]; then
   BUILDKITE_COMMIT="$(git rev-parse "$2")"
 else
   echo "Usage: git buildkite [branch [commit]]"
+fi
+
+if is_protected_branch "$BUILDKITE_BRANCH" && [ -z "$force" ]; then
+  echo "Whoops, the branch \`$BUILDKITE_BRANCH' is protected"
+  echo
+  echo "If you want to force the build anyway, try:"
+  echo
+  echo "    git buildkite --force [branch [commit]]"
+  echo
+  echo "These branches are currently protected:"
+  echo
+  for branch in $(protected_branches); do
+    echo "    $branch"
+  done
+  echo
+  echo "To stop protecting the \`$BUILDKITE_BRANCH' branch remove the key:"
+  echo
+  echo "    git config --local buildkite.protectedBranches \$(git config --local buildkite.protectedBranches | tr ',' '\\n' | grep -v -- \"$BUILDKITE_BRANCH\" | paste -sd ',' -)"
+  echo
+  exit 1
 fi
 
 echo "Starting a build for $BUILDKITE_BRANCH at $BUILDKITE_COMMIT"


### PR DESCRIPTION
This is a first stab at protected branches. An example use case of this is when a green Buildkite branch on master triggers an automatic deploy in a continuous delivery setup.

The idea here is that one can set `git config --local buildkite.protectedBranches master,another-branch,blah` to store a list of branch names that `git buildkite` should not build. A new `--force` flag is introduced to allow one to force a build when necessary. 

Another idea I had was to introduce a git hook-like script, such as `.git/hooks/buildkite-check` that would be executed on `git buildkite` before the build step. If `buildkite-check` exited non-zero, that would stop the build from being created.

I went with the git config version because I thought it would be simpler, especially for people who wanted to do `git config --global buildkite.protectedBranches`. If more flexibility is desired, the hook method may be a better alternative, but I would love to hear use-cases first. 

Soliciting feedback on the general approach before I open a pull upstream.